### PR TITLE
Made core-foundation a dependency for any platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,4 @@ license = "MIT / Apache-2.0"
 
 [dependencies]
 libc = "*"
-
-[target.x86_64-apple-darwin.dependencies]
 core-foundation = "*"


### PR DESCRIPTION
The Cargo.toml file currently only declares `core-foundation` as a dependency on 64bit OSX, but it's used unconditionally in this crate so it should be an unconditional dependency.

I'm playing around with this crate on iOS and it won't build without this change.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/39)
<!-- Reviewable:end -->
