### PR TITLE
Fix CGFloat type definition for 32-bit

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -13,13 +13,18 @@
 
 use libc;
 
-#[cfg(target_pointer_width = "32")]
-pub type boolean_t = i32;
-#[cfg(target_pointer_width = "64")]
-pub type boolean_t = u32;
+#[cfg(any(target_arch = "x86",
+          target_arch = "arm",
+          target_arch = "aarch64"))]
+pub type boolean_t = libc::c_int;
+#[cfg(target_arch = "x86_64")]
+pub type boolean_t = libc::c_uint;
 
-// TODO: this is actually a libc::c_float on 32bit
+#[cfg(target_pointer_width = "64")]
 pub type CGFloat = libc::c_double;
+#[cfg(not(target_pointer_width = "64"))]
+pub type CGFloat = libc::c_float;
+
 pub type CGError = libc::int32_t;
 
 pub type CGAffineTransform = ();


### PR DESCRIPTION
`CGFloat` was always defined as a double, and there was a `TODO` to fix this. I ran into the issue, so here's a PR to fix it :)

The definition for `CGFloat` in CoreGraphics/CGBase.h looks like:
``` c
#if defined(__LP64__) && __LP64__
# define CGFLOAT_TYPE double
#else
# define CGFLOAT_TYPE float
#endif

typedef CGFLOAT_TYPE CGFloat;
```

I also noticed that the definition for `boolean_t` was wrong for arm. The definition in mach/arm/boolean.h is:
``` c
typedef int		boolean_t;
```

And the definition in mach/i386/boolean.h is:
``` c
#if defined(__x86_64__) && !defined(KERNEL)
typedef unsigned int	boolean_t;
#else
typedef int		boolean_t;
#endif
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/42)
<!-- Reviewable:end -->
