### PR TITLE
Support serialization of `CGFont` objects.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ license = "MIT / Apache-2.0"
 [dependencies]
 libc = "0.2"
 core-foundation = "0.2"
+serde = "0.6"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 extern crate libc;
 extern crate core_foundation;
+extern crate serde;
 
 pub mod base;
 pub mod color_space;


### PR DESCRIPTION
Due to API limitations, this will only serialize native fonts, not Web
fonts. Specifically, there is no way I know of to fetch the
`CGDataProvider` associated with a `CGFont`. This isn't a problem for
Servo, however, because Servo knows which fonts are Web fonts and stores
their byte data separately.

r? @glennw or @larsbergstrom

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/46)
<!-- Reviewable:end -->
