### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for OS X"
 homepage = "https://github.com/servo/core-graphics-rs"
 repository = "https://github.com/servo/core-graphics-rs"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 


### PR DESCRIPTION
In order to pick up this change:

https://github.com/servo/core-graphics-rs/pull/46

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/47)
<!-- Reviewable:end -->
