### PR TITLE
Add some bindings to the private `CGSRegion` APIs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,5 @@ pub mod data_provider;
 pub mod display;
 pub mod font;
 pub mod geometry;
+pub mod private;
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,0 +1,57 @@
+// Copyright 2016 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Evil private APIs.
+//!
+//! These are liable to change at any time. Use with caution!
+
+use geometry::CGRect;
+use std::ptr;
+
+pub struct CGSRegion {
+    region: ffi::CGSRegion,
+}
+
+impl Drop for CGSRegion {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::CGSRegionRelease(self.region)
+        }
+    }
+}
+
+impl CGSRegion {
+    #[inline]
+    pub fn from_rect(rect: &CGRect) -> CGSRegion {
+        unsafe {
+            let mut region = ptr::null_mut();
+            assert!(ffi::CGSNewRegionWithRect(rect, &mut region) == 0);
+            CGSRegion {
+                region: region,
+            }
+        }
+    }
+}
+
+mod ffi {
+    use geometry::CGRect;
+
+    // This is an enum so that we can't easily make instances of this opaque type.
+    enum CGSRegionObject {}
+
+    pub type CGSRegion = *mut CGSRegionObject;
+    pub type OSStatus = i32;
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    extern {
+        pub fn CGSRegionRelease(region: CGSRegion);
+        pub fn CGSNewRegionWithRect(rect: *const CGRect, region: *mut CGSRegion) -> OSStatus;
+    }
+}
+


### PR DESCRIPTION
These enable us to tell the window server about the opaque regions of
the window so that it can perform occlusion culling.

See https://github.com/NUIKit/CGSInternal/blob/master/CGSRegion.h

r? @metajack

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/50)
<!-- Reviewable:end -->
