### PR TITLE
Add bindings to the private `CGSNewRegionWithRectList` and `CGSSetSurfaceShape` APIs, and improve ergonomics of the geometry types.

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -9,6 +9,11 @@
 
 use base::CGFloat;
 
+pub const CG_ZERO_POINT: CGPoint = CGPoint {
+    x: 0.0,
+    y: 0.0,
+};
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct CGSize {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -63,5 +63,22 @@ impl CGRect {
             size: *size,
         }
     }
+
+    #[inline]
+    pub fn inset(&self, size: &CGSize) -> CGRect {
+        unsafe {
+            ffi::CGRectInset(*self, size.width, size.height)
+        }
+    }
+}
+
+mod ffi {
+    use base::CGFloat;
+    use geometry::CGRect;
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    extern {
+        pub fn CGRectInset(rect: CGRect, dx: CGFloat, dy: CGFloat) -> CGRect;
+    }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -21,11 +21,31 @@ pub struct CGSize {
     pub height: CGFloat,
 }
 
+impl CGSize {
+    #[inline]
+    pub fn new(width: CGFloat, height: CGFloat) -> CGSize {
+        CGSize {
+            width: width,
+            height: height,
+        }
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct CGPoint {
     pub x: CGFloat,
     pub y: CGFloat,
+}
+
+impl CGPoint {
+    #[inline]
+    pub fn new(x: CGFloat, y: CGFloat) -> CGPoint {
+        CGPoint {
+            x: x,
+            y: y,
+        }
+    }
 }
 
 #[repr(C)]
@@ -34,3 +54,14 @@ pub struct CGRect {
     pub origin: CGPoint,
     pub size: CGSize
 }
+
+impl CGRect {
+    #[inline]
+    pub fn new(origin: &CGPoint, size: &CGSize) -> CGRect {
+        CGRect {
+            origin: *origin,
+            size: *size,
+        }
+    }
+}
+

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -10,18 +10,21 @@
 use base::CGFloat;
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug)]
 pub struct CGSize {
     pub width: CGFloat,
     pub height: CGFloat,
 }
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug)]
 pub struct CGPoint {
     pub x: CGFloat,
     pub y: CGFloat,
 }
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug)]
 pub struct CGRect {
     pub origin: CGPoint,
     pub size: CGSize

--- a/src/private.rs
+++ b/src/private.rs
@@ -15,7 +15,7 @@ use geometry::CGRect;
 use std::ptr;
 
 pub struct CGSRegion {
-    region: ffi::CGSRegion,
+    region: ffi::CGSRegionRef,
 }
 
 impl Drop for CGSRegion {
@@ -45,13 +45,14 @@ mod ffi {
     // This is an enum so that we can't easily make instances of this opaque type.
     enum CGSRegionObject {}
 
-    pub type CGSRegion = *mut CGSRegionObject;
+    pub type CGError = OSStatus;
+    pub type CGSRegionRef = *mut CGSRegionObject;
     pub type OSStatus = i32;
 
     #[link(name = "ApplicationServices", kind = "framework")]
     extern {
-        pub fn CGSRegionRelease(region: CGSRegion);
-        pub fn CGSNewRegionWithRect(rect: *const CGRect, region: *mut CGSRegion) -> OSStatus;
+        pub fn CGSRegionRelease(region: CGSRegionRef);
+        pub fn CGSNewRegionWithRect(rect: *const CGRect, outRegion: *mut CGSRegionRef) -> CGError;
     }
 }
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -37,10 +37,24 @@ impl CGSRegion {
             }
         }
     }
+
+    #[inline]
+    pub fn from_rects(rects: &[CGRect]) -> CGSRegion {
+        unsafe {
+            let mut region = ptr::null_mut();
+            assert!(ffi::CGSNewRegionWithRectList(rects.as_ptr(),
+                                                  rects.len() as c_uint,
+                                                  &mut region) == 0);
+            CGSRegion {
+                region: region,
+            }
+        }
+    }
 }
 
 mod ffi {
     use geometry::CGRect;
+    use libc::c_uint;
 
     // This is an enum so that we can't easily make instances of this opaque type.
     enum CGSRegionObject {}
@@ -53,6 +67,10 @@ mod ffi {
     extern {
         pub fn CGSRegionRelease(region: CGSRegionRef);
         pub fn CGSNewRegionWithRect(rect: *const CGRect, outRegion: *mut CGSRegionRef) -> CGError;
+        pub fn CGSNewRegionWithRectList(rects: *const CGRect,
+                                        rectCount: c_uint,
+                                        outRegion: *mut CGSRegionRef)
+                                        -> CGError;
     }
 }
 


### PR DESCRIPTION
These changes allow us to set rounded corners on OpenGL views the same way Cocoa does, dramatically improving performance.

r? @metajack 
cc @paulrouget

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/51)
<!-- Reviewable:end -->
