### PR TITLE
removed dependency on serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ elcapitan = []
 [dependencies]
 libc = "0.2"
 core-foundation = "0.3"
-serde = "0.8"

--- a/src/font.rs
+++ b/src/font.rs
@@ -12,8 +12,6 @@ use core_foundation::string::{CFString, CFStringRef};
 use data_provider::{CGDataProvider, CGDataProviderRef};
 
 use libc;
-use serde::de::{self, Deserialize, Deserializer};
-use serde::ser::{Serialize, Serializer};
 use std::mem;
 use std::ptr;
 
@@ -30,22 +28,6 @@ pub struct CGFont {
 
 unsafe impl Send for CGFont {}
 unsafe impl Sync for CGFont {}
-
-impl Serialize for CGFont {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
-        let postscript_name = self.postscript_name().to_string();
-        postscript_name.serialize(serializer)
-    }
-}
-
-impl Deserialize for CGFont {
-    fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error> where D: Deserializer {
-        let postscript_name: String = try!(Deserialize::deserialize(deserializer));
-        CGFont::from_name(&CFString::new(&*postscript_name)).map_err(|_| {
-            de::Error::invalid_value("Couldn't find a font with that PostScript name!")
-        })
-    }
-}
 
 impl Clone for CGFont {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 
 extern crate libc;
 extern crate core_foundation;
-extern crate serde;
 
 pub mod base;
 pub mod color_space;


### PR DESCRIPTION
The `Serialize`/`Deserialize` implementations have moved to webrender.

See https://github.com/servo/servo/issues/15607

Other related pull requests:
 * https://github.com/servo/servo/pull/15615
 * https://github.com/servo/webrender/pull/896

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/75)
<!-- Reviewable:end -->
