### PR TITLE
Remove serde crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,4 @@ elcapitan = []
 [dependencies]
 libc = "0.2"
 core-foundation = "0.3"
-serde = "0.9"
 bitflags = "0.8"

--- a/src/font.rs
+++ b/src/font.rs
@@ -12,8 +12,6 @@ use core_foundation::string::{CFString, CFStringRef};
 use data_provider::{CGDataProvider, CGDataProviderRef};
 
 use libc;
-use serde::de::{self, Deserialize, Deserializer};
-use serde::ser::{Serialize, Serializer};
 use std::mem;
 use std::ptr;
 
@@ -30,22 +28,6 @@ pub struct CGFont {
 
 unsafe impl Send for CGFont {}
 unsafe impl Sync for CGFont {}
-
-impl Serialize for CGFont {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-        let postscript_name = self.postscript_name().to_string();
-        postscript_name.serialize(serializer)
-    }
-}
-
-impl Deserialize for CGFont {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer {
-        let postscript_name: String = try!(Deserialize::deserialize(deserializer));
-        CGFont::from_name(&CFString::new(&*postscript_name)).map_err(|_| {
-            de::Error::custom("Couldn't find a font with that PostScript name!")
-        })
-    }
-}
 
 impl Clone for CGFont {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 
 extern crate libc;
 extern crate core_foundation;
-extern crate serde;
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
Remove ```serde``` from ```core-graphics-rs```. The serialization function moves to ```webrender```.

https://github.com/servo/servo/issues/15607

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/82)
<!-- Reviewable:end -->
