### PR TITLE
Adds an additional display function + bumps core-foundation dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for OS X"
 homepage = "https://github.com/servo/core-graphics-rs"
 repository = "https://github.com/servo/core-graphics-rs"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 
@@ -12,6 +12,6 @@ default = []
 elcapitan = []
 
 [dependencies]
-libc = "0.2"
-core-foundation = "0.3"
 bitflags = "0.9"
+core-foundation = "0.4"
+libc = "0.2"

--- a/src/display.rs
+++ b/src/display.rs
@@ -76,6 +76,7 @@ extern {
     pub fn CGDisplayPixelsHigh(display: CGDirectDisplayID) -> libc::size_t;
     pub fn CGDisplayPixelsWide(display: CGDirectDisplayID) -> libc::size_t;
     pub fn CGDisplayBounds(display: CGDirectDisplayID) -> CGRect;
+    pub fn CGDisplayCreateImage(display: CGDirectDisplayID) -> CGImageRef;
 
     // mouse stuff
     pub fn CGDisplayHideCursor(display: CGDirectDisplayID) -> CGError;

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -85,6 +85,22 @@ impl CGRect {
             Some(rect)
         }
     }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        unsafe {
+            // I use one, as it seems that `YES` is not available from this crate.
+            ffi::CGRectIsEmpty(*self) == 1
+        }
+    }
+
+    #[inline]
+    pub fn is_intersects(&self, other: &CGRect) -> bool {
+        unsafe {
+            // I use one, as it seems that `YES` is not available from this crate.
+            ffi::CGRectIntersectsRect(*self, *other) == 1
+        }
+    }
 }
 
 mod ffi {
@@ -97,6 +113,8 @@ mod ffi {
         pub fn CGRectInset(rect: CGRect, dx: CGFloat, dy: CGFloat) -> CGRect;
         pub fn CGRectMakeWithDictionaryRepresentation(dict: CFDictionaryRef,
                                                       rect: *mut CGRect) -> boolean_t;
+        pub fn CGRectIsEmpty(rect: CGRect) -> boolean_t;
+        pub fn CGRectIntersectsRect(rect1: CGRect, rect2: CGRect) -> boolean_t;
     }
 }
 


### PR DESCRIPTION
This is a small pull request, basically it adds the following things:

1. Adds a missing `CGDisplayCreateImage()` function, so that now the user has all required functions to capture static images (it was already implemented for window capturing and now the display capturing is also possible).
2. Adds a couple functions to `CGRect`.
3. Updates the version for `core-foundation` from `0.3` to `0.4`. I'm not sure if using `0.3` makes sense if we can use `0.4`. For me personally it was required to change it as my project depends on several crates, including the latest `core-foundation` version, so when I have both `core-graphics` and `core-foundation` in my dependencies, `core-foundation` has been compiled twice (once for `0.4` which is the new version and once for the old `0.3` which has been downloaded and compiled as one of the `core-graphics` dependencies). So basically the people who use the both `core-graphics` and `core-foundation` (the last versions) would encounter the same problems (`core-foundation` is compiled twice and it may cause compile time errors like it was in my case). What are your thoughts on these?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/87)
<!-- Reviewable:end -->
