### PR TITLE
Remove warnings for zero-sized structs 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for OS X"
 homepage = "https://github.com/servo/core-graphics-rs"
 repository = "https://github.com/servo/core-graphics-rs"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 
@@ -13,5 +13,5 @@ elcapitan = []
 
 [dependencies]
 bitflags = "0.9"
-core-foundation = "0.4"
+core-foundation = { path = "../core-foundation-rs/core-foundation" } #"0.4"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ elcapitan = []
 
 [dependencies]
 bitflags = "0.9"
-core-foundation = { path = "../core-foundation-rs/core-foundation" } #"0.4"
+core-foundation = "0.4"
 libc = "0.2"

--- a/src/base.rs
+++ b/src/base.rs
@@ -28,7 +28,9 @@ pub type CGFloat = libc::c_float;
 
 pub type CGError = libc::int32_t;
 
-pub type CGAffineTransform = ();
+// This is an enum due to zero-sized types warnings.
+// For more details see https://github.com/rust-lang/rust/issues/27303
+pub enum CGAffineTransform {}
 
 pub const kCGImageAlphaNone: u32 = 0;
 pub const kCGImageAlphaPremultipliedLast: u32 = 1;

--- a/src/color_space.rs
+++ b/src/color_space.rs
@@ -10,8 +10,9 @@
 use core_foundation::base::{CFRelease, CFRetain, CFTypeID, CFTypeRef, TCFType};
 use std::mem;
 
-#[repr(C)]
-pub struct __CGColorSpace;
+// This is an enum due to zero-sized types warnings.
+// For more details see https://github.com/rust-lang/rust/issues/27303
+pub enum __CGColorSpace {}
 
 pub type CGColorSpaceRef = *const __CGColorSpace;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -28,8 +28,9 @@ pub enum CGTextDrawingMode {
     CGTextClip
 }
 
-#[repr(C)]
-pub struct __CGContext;
+// This is an enum due to zero-sized types warnings.
+// For more details see https://github.com/rust-lang/rust/issues/27303
+pub enum __CGContext {}
 
 pub type CGContextRef = *const __CGContext;
 

--- a/src/data_provider.rs
+++ b/src/data_provider.rs
@@ -26,8 +26,9 @@ pub type CGDataProviderReleaseBytePointerCallback = Option<unsafe extern fn (*mu
 pub type CGDataProviderReleaseDataCallback = Option<unsafe extern fn (*mut c_void, *const c_void, size_t)>;
 pub type CGDataProviderGetBytesAtPositionCallback = Option<unsafe extern fn (*mut c_void, *mut c_void, off_t, size_t)>;
 
-#[repr(C)]
-pub struct __CGDataProvider;
+// This is an enum due to zero-sized types warnings.
+// For more details see https://github.com/rust-lang/rust/issues/27303
+pub enum __CGDataProvider {}
 
 pub type CGDataProviderRef = *const __CGDataProvider;
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -12,6 +12,7 @@ pub type CGKeyCode = libc::uint16_t;
 ///
 /// [Ref](http://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-700/IOHIDSystem/IOKit/hidsystem/IOLLEvent.h)
 bitflags! {
+    #[repr(C)]
     pub struct CGEventFlags: u64 {
         const CGEventFlagNull = 0;
 
@@ -88,8 +89,9 @@ pub enum CGEventTapLocation {
     AnnotatedSession,
 }
 
-#[repr(C)]
-pub struct __CGEvent;
+// This is an enum due to zero-sized types warnings.
+// For more details see https://github.com/rust-lang/rust/issues/27303
+pub enum __CGEvent {}
 
 pub type CGEventRef = *const __CGEvent;
 

--- a/src/event_source.rs
+++ b/src/event_source.rs
@@ -12,8 +12,9 @@ pub enum CGEventSourceStateID {
     HIDSystemState = 1,
 }
 
-#[repr(C)]
-pub struct __CGEventSource;
+// This is an enum due to zero-sized types warnings.
+// For more details see https://github.com/rust-lang/rust/issues/27303
+pub enum __CGEventSource {}
 
 pub type CGEventSourceRef = *const __CGEventSource;
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -17,8 +17,9 @@ use std::ptr;
 
 pub type CGGlyph = libc::c_ushort;
 
-#[repr(C)]
-pub struct __CGFont;
+// This is an enum due to zero-sized types warnings.
+// For more details see https://github.com/rust-lang/rust/issues/27303
+pub enum __CGFont {}
 
 pub type CGFontRef = *const __CGFont;
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -27,8 +27,9 @@ pub enum CGImageByteOrderInfo {
     CGImageByteOrder32Big = (4 << 12)
 }
 
-#[repr(C)]
-pub struct __CGImage;
+// This is an enum due to zero-sized types warnings.
+// For more details see https://github.com/rust-lang/rust/issues/27303
+pub enum __CGImage {}
 
 pub type CGImageRef = *const __CGImage;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 extern crate libc;
-#[macro_use]
 extern crate core_foundation;
 
 #[macro_use]


### PR DESCRIPTION
This change removes a bunch of warnings from the crate.

The only remaining warnings are due to the bitflags macro usage.

This will help fix servo/core-text-rs#62 when it upgrades to `core-graphics = 0.9`.

@jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/90)
<!-- Reviewable:end -->
