### PR TITLE
Add support for iOS targets

### DIFF
--- a/src/color_space.rs
+++ b/src/color_space.rs
@@ -42,7 +42,7 @@ impl CGColorSpace {
     }
 }
 
-#[link(name = "ApplicationServices", kind = "framework")]
+#[link(name = "CoreGraphics", kind = "framework")]
 extern {
     pub static kCGColorSpaceSRGB: CFStringRef;
     pub static kCGColorSpaceAdobeRGB1998: CFStringRef;

--- a/src/context.rs
+++ b/src/context.rs
@@ -204,7 +204,7 @@ fn create_bitmap_context_test() {
     assert_eq!(255, data.bytes()[3]);
 }
 
-#[link(name = "ApplicationServices", kind = "framework")]
+#[link(name = "CoreGraphics", kind = "framework")]
 extern {
     fn CGBitmapContextCreate(data: *mut c_void,
                              width: size_t,

--- a/src/data_provider.rs
+++ b/src/data_provider.rs
@@ -61,7 +61,7 @@ impl CGDataProviderRef {
     }
 }
 
-#[link(name = "ApplicationServices", kind = "framework")]
+#[link(name = "CoreGraphics", kind = "framework")]
 extern {
     fn CGDataProviderCopyData(provider: ::sys::CGDataProviderRef) -> CFDataRef;
     //fn CGDataProviderCreateDirect

--- a/src/display.rs
+++ b/src/display.rs
@@ -399,7 +399,7 @@ impl CGDisplayMode {
     }
 }
 
-#[link(name = "ApplicationServices", kind = "framework")]
+#[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
     pub static CGRectNull: CGRect;
     pub static CGRectInfinite: CGRect;

--- a/src/event.rs
+++ b/src/event.rs
@@ -507,7 +507,7 @@ impl CGEvent {
     }
 }
 
-#[link(name = "ApplicationServices", kind = "framework")]
+#[link(name = "CoreGraphics", kind = "framework")]
 extern {
     /// Return the type identifier for the opaque type `CGEventRef'.
     fn CGEventGetTypeID() -> CFTypeID;

--- a/src/event_source.rs
+++ b/src/event_source.rs
@@ -38,7 +38,7 @@ impl CGEventSource {
     }
 }
 
-#[link(name = "ApplicationServices", kind = "framework")]
+#[link(name = "CoreGraphics", kind = "framework")]
 extern {
     /// Return the type identifier for the opaque type `CGEventSourceRef'.
     fn CGEventSourceGetTypeID() -> CFTypeID;

--- a/src/font.rs
+++ b/src/font.rs
@@ -66,7 +66,7 @@ impl CGFont {
     }
 }
 
-#[link(name = "ApplicationServices", kind = "framework")]
+#[link(name = "CoreGraphics", kind = "framework")]
 extern {
     // TODO: basically nothing has bindings (even commented-out) besides what we use.
     fn CGFontCreateWithDataProvider(provider: ::sys::CGDataProviderRef) -> ::sys::CGFontRef;

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -108,7 +108,7 @@ mod ffi {
     use geometry::CGRect;
     use core_foundation::dictionary::CFDictionaryRef;
 
-    #[link(name = "ApplicationServices", kind = "framework")]
+    #[link(name = "CoreGraphics", kind = "framework")]
     extern {
         pub fn CGRectInset(rect: CGRect, dx: CGFloat, dy: CGFloat) -> CGRect;
         pub fn CGRectMakeWithDictionaryRepresentation(dict: CFDictionaryRef,

--- a/src/image.rs
+++ b/src/image.rs
@@ -92,7 +92,7 @@ impl CGImageRef {
     }
 }
 
-#[link(name = "ApplicationServices", kind = "framework")]
+#[link(name = "CoreGraphics", kind = "framework")]
 extern {
     fn CGImageGetTypeID() -> CFTypeID;
     fn CGImageGetWidth(image: ::sys::CGImageRef) -> size_t;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate libc;
 extern crate core_foundation;
 
 #[macro_use]
+#[cfg(target_os = "macos")]
 extern crate bitflags;
 
 #[macro_use]
@@ -20,11 +21,15 @@ pub mod base;
 pub mod color_space;
 pub mod context;
 pub mod data_provider;
+#[cfg(target_os = "macos")]
 pub mod display;
+#[cfg(target_os = "macos")]
 pub mod event;
+#[cfg(target_os = "macos")]
 pub mod event_source;
 pub mod font;
 pub mod geometry;
+#[cfg(target_os = "macos")]
 pub mod private;
 pub mod image;
 mod sys;

--- a/src/private.rs
+++ b/src/private.rs
@@ -97,7 +97,7 @@ mod ffi {
     pub type CGSRegionRef = *mut CGSRegionObject;
     pub type OSStatus = i32;
 
-    #[link(name = "ApplicationServices", kind = "framework")]
+    #[link(name = "CoreGraphics", kind = "framework")]
     extern {
         pub fn CGSRegionRelease(region: CGSRegionRef);
         pub fn CGSNewRegionWithRect(rect: *const CGRect, outRegion: *mut CGSRegionRef) -> CGError;

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -10,16 +10,20 @@ pub type CGDataProviderRef = *mut CGDataProvider;
 pub enum CGFont {}
 pub type CGFontRef = *mut CGFont;
 
-pub enum CGEvent {}
-pub type CGEventRef = *mut CGEvent;
-
-pub enum CGEventSource {}
-pub type CGEventSourceRef = *mut CGEventSource;
-
 pub enum CGContext {}
 pub type CGContextRef = *mut CGContext;
 
-pub enum CGDisplayMode {}
-pub type CGDisplayModeRef = *mut CGDisplayMode;
+#[cfg(target_os = "macos")]
+mod macos {
+	pub enum CGEvent {}
+	pub type CGEventRef = *mut CGEvent;
 
+	pub enum CGEventSource {}
+	pub type CGEventSourceRef = *mut CGEventSource;
 
+	pub enum CGDisplayMode {}
+	pub type CGDisplayModeRef = *mut CGDisplayMode;
+}
+
+#[cfg(target_os = "macos")]
+pub use self::macos::*;


### PR DESCRIPTION
Only include `CGEvent` and `CGDisplay` on macOS, and link against `CoreGraphics` specifically, not the macOS umbrella framework.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/99)
<!-- Reviewable:end -->
