### PR TITLE
Fix memory safety problem in `CGDataProvider::from_buffer()`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for OS X"
 homepage = "https://github.com/servo/core-graphics-rs"
 repository = "https://github.com/servo/core-graphics-rs"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 


### PR DESCRIPTION
The wrapper for that function made no attempt to ensure that the buffer
would stay alive, and as a result use-after-free could easily occur. The
fix is to require that the buffer be stuffed in an `Arc` box and to
teach Core Graphics how to release the `Arc` when it's done with it.

Related: #77. (This is basically a more minimal version of that PR. I had seen #77 but didn't realize that it was a memory safety problem! If you'd like to merge that PR instead, feel free.)

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/101)
<!-- Reviewable:end -->
