### PR TITLE
Add a binding to `CGFontGetUnitsPerEm()`

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -85,6 +85,12 @@ impl CGFont {
                                    advances.as_mut_ptr())
         }
     }
+
+    pub fn get_units_per_em(&self) -> c_int {
+        unsafe {
+            CGFontGetUnitsPerEm(self.as_ptr())
+        }
+    }
 }
 
 #[link(name = "CoreGraphics", kind = "framework")]
@@ -111,4 +117,5 @@ extern {
                               count: size_t,
                               advances: *mut c_int)
                               -> bool;
+    fn CGFontGetUnitsPerEm(font: ::sys::CGFontRef) -> c_int;
 }


### PR DESCRIPTION
Pathfinder 2 is using this. It saves a little bit of time and memory by avoiding creation of `CTFont` objects just to do this simple query.

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/103)
<!-- Reviewable:end -->
