### PR TITLE
extend support for CGAffineTransform in geometry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for OS X"
 homepage = "https://github.com/servo/core-graphics-rs"
 repository = "https://github.com/servo/core-graphics-rs"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,7 +17,7 @@ use libc::{c_void, c_int, size_t};
 use std::cmp;
 use std::ptr;
 use std::slice;
-use geometry::CGRect;
+use geometry::{CGAffineTransform, CGRect};
 use image::CGImage;
 use foreign_types::ForeignType;
 
@@ -194,6 +194,12 @@ impl CGContext {
         }
     }
 
+    pub fn set_text_matrix(&self, t: &CGAffineTransform) {
+        unsafe {
+            CGContextSetTextMatrix(self.as_ptr(), *t)
+        }
+    }
+
     pub fn show_glyphs_at_positions(&self, glyphs: &[CGGlyph], positions: &[CGPoint]) {
         unsafe {
             let count = cmp::min(glyphs.len(), positions.len());
@@ -269,6 +275,7 @@ extern {
     fn CGContextDrawImage(c: ::sys::CGContextRef, rect: CGRect, image: ::sys::CGImageRef);
     fn CGContextSetFont(c: ::sys::CGContextRef, font: ::sys::CGFontRef);
     fn CGContextSetFontSize(c: ::sys::CGContextRef, size: CGFloat);
+    fn CGContextSetTextMatrix(c: ::sys::CGContextRef, t: CGAffineTransform);
     fn CGContextShowGlyphsAtPositions(c: ::sys::CGContextRef,
                                       glyphs: *const CGGlyph,
                                       positions: *const CGPoint,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -47,6 +47,13 @@ impl CGSize {
             height: height,
         }
     }
+
+    #[inline]
+    pub fn apply_transform(&self, t: &CGAffineTransform) -> CGSize {
+        unsafe {
+            ffi::CGSizeApplyAffineTransform(*self, *t)
+        }
+    }
 }
 
 #[repr(C)]
@@ -62,6 +69,13 @@ impl CGPoint {
         CGPoint {
             x: x,
             y: y,
+        }
+    }
+
+    #[inline]
+    pub fn apply_transform(&self, t: &CGAffineTransform) -> CGPoint {
+        unsafe {
+            ffi::CGPointApplyAffineTransform(*self, *t)
         }
     }
 }
@@ -117,9 +131,17 @@ impl CGRect {
             ffi::CGRectIntersectsRect(*self, *other) == 1
         }
     }
+
+    #[inline]
+    pub fn apply_transform(&self, t: &CGAffineTransform) -> CGRect {
+        unsafe {
+            ffi::CGRectApplyAffineTransform(*self, *t)
+        }
+    }
 }
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct CGAffineTransform {
     pub a: CGFloat,
     pub b: CGFloat,
@@ -129,9 +151,30 @@ pub struct CGAffineTransform {
     pub ty: CGFloat,
 }
 
+impl CGAffineTransform {
+    #[inline]
+    pub fn new(
+        a: CGFloat,
+        b: CGFloat,
+        c: CGFloat,
+        d: CGFloat,
+        tx: CGFloat,
+        ty: CGFloat,
+    ) -> CGAffineTransform {
+        CGAffineTransform { a, b, c, d, tx, ty }
+    }
+
+    #[inline]
+    pub fn invert(&self) -> CGAffineTransform {
+        unsafe {
+            ffi::CGAffineTransformInvert(*self)
+        }
+    }
+}
+
 mod ffi {
     use base::{CGFloat, boolean_t};
-    use geometry::CGRect;
+    use geometry::{CGAffineTransform, CGPoint, CGRect, CGSize};
     use core_foundation::dictionary::CFDictionaryRef;
 
     #[link(name = "CoreGraphics", kind = "framework")]
@@ -141,6 +184,12 @@ mod ffi {
                                                       rect: *mut CGRect) -> boolean_t;
         pub fn CGRectIsEmpty(rect: CGRect) -> boolean_t;
         pub fn CGRectIntersectsRect(rect1: CGRect, rect2: CGRect) -> boolean_t;
+
+        pub fn CGAffineTransformInvert(t: CGAffineTransform) -> CGAffineTransform;
+
+        pub fn CGPointApplyAffineTransform(point: CGPoint, t: CGAffineTransform) -> CGPoint;
+        pub fn CGRectApplyAffineTransform(rect: CGRect, t: CGAffineTransform) -> CGRect;
+        pub fn CGSizeApplyAffineTransform(size: CGSize, t: CGAffineTransform) -> CGSize;
     }
 }
 


### PR DESCRIPTION
These changes are necessary to support subpixel AA transforms in WebRender on macOS. Otherwise, it is a bit of a pain to do all the necessary CGContext manipulation using the raw types and prying the data from core-graphics-rs to do so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/108)
<!-- Reviewable:end -->
