### PR TITLE
Upgrade core foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ elcapitan = []
 
 [dependencies]
 bitflags = "1.0"
-core-foundation = "0.4.5"
+core-foundation = "0.5"
 foreign-types = "0.3.0"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "core-graphics"
 description = "Bindings to Core Graphics for OS X"
 homepage = "https://github.com/servo/core-graphics-rs"
 repository = "https://github.com/servo/core-graphics-rs"
-version = "0.12.4"
+version = "0.13.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 


### PR DESCRIPTION
This is a PR in a series of PRs originating at https://github.com/servo/core-foundation-rs/pull/132

The plan is to make a breaking change to `core-foundation` and release it as `0.5.0`. But before the merge/publish of `core-foundation` I will prepare a set of PRs making sure the entire dependency graph of Servo is ready for this change and can be switched over to `0.5.0` directly.

TODO before merge:
- [x] Merge `core-foundation` PR and publish.
- [x] Remove the last commit from this PR, so we depend on `core-foundation` from crates.io.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/core-graphics-rs/110)
<!-- Reviewable:end -->
